### PR TITLE
Support ranges and new command for registers.

### DIFF
--- a/vim/autoload/remotecopy.vim
+++ b/vim/autoload/remotecopy.vim
@@ -9,14 +9,31 @@ set cpo&vim
 
 let s:secret = 'none'
 
-function! remotecopy#docopy()
-    let output = system("remotecopy -n -s ".s:secret, getreg(""))
+function! remotecopy#docopy(line1, line2)
+    let s:copy_text = getline(a:line1, a:line2)
+    let output = system("remotecopy -n -s ".s:secret, join(s:copy_text,"\r"))
     if v:shell_error
         if v:shell_error == 1
             " if it's exit code 1, then we need to reauth
             echo "Need to auth"
             let s:secret = input("Input secret: ")
-            call remotecopy#docopy()
+            call remotecopy#docopy(a:line1, a:line2)
+        else
+            echo output
+        endif
+    else
+        echo "Remote copied."
+    endif
+endfunction
+
+function! remotecopy#copyreg()
+    let output = system("remotecopy -n -s ".s:secret, getreg(v:register))
+    if v:shell_error
+        if v:shell_error == 1
+            " if it's exit code 1, then we need to reauth
+            echo "Need to auth"
+            let s:secret = input("Input secret: ")
+            call remotecopy#copyreg()
         else
             echo output
         endif

--- a/vim/plugin/remotecopy.vim
+++ b/vim/plugin/remotecopy.vim
@@ -8,10 +8,11 @@ let g:loaded_remotecopy = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-" TODO: support passing in a register
-command! RemoteCopy call remotecopy#docopy()
+command -range=% RemoteCopy call remotecopy#docopy(<line1>, <line2>)
+command RemoteCopyRegister call remotecopy#copyreg()
 
 " probably a better way to do this
 noremap <leader>y :RemoteCopy<CR>
+noremap <leader>r :RemoteCopyRegister<CR>
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
The current workflow remains the same as <leader>y remotecopies the entire buffer.

This however allows you to visually select blocks of text and <leader>y only that text.

This also adds a new command <leader>r to remote copy the register of your choice
i.e.   "x,r     will remotecopy register x.
