### PR TITLE
if linux, then xsel, else pbcopy

### DIFF
--- a/remotecopyserver
+++ b/remotecopyserver
@@ -102,7 +102,12 @@ sub copy {
     my $copydata = shift;
 
     my $pbcopy;
-    open( $pbcopy, "|pbcopy" ) or die "unable to open $!";
+    if ($^O eq "linux") {
+        open( $pbcopy, "|xsel --clipboard --input")
+            or die "unable to open $!";
+    } else {
+        open( $pbcopy, "|pbcopy" ) or die "unable to open $!";
+    }
     print $pbcopy $copydata;
     close($pbcopy);
 }


### PR DESCRIPTION
I successfully used this script on my Mac, but it failed to work on my Ubuntu laptop.

Now, `remotecopyserver` will check the operating system and use `xsel` on
linux and `pbcopy` on Mac. I tested it and it works with my Ubuntu setup.
